### PR TITLE
Fix travis build error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
     - pip install pipenv
     - pipenv install --system --skip-lock
 before_script:
-    - sudo cat "$TRAVIS_BUILD_DIR/RubikVNdotOrg/db/my.cnf" > /etc/mysql/my.cnf
+    - sed -n 22,33p "$TRAVIS_BUILD_DIR/RubikVNdotOrg/db/my.cnf" | sudo tee -a /etc/mysql/my.cnf
     - sudo service mysql restart
     - mysql -e 'CREATE DATABASE IF NOT EXISTS test_rubikvn;'
     - mysql -u root --default-character-set=utf8mb4 test_rubikvn < $TRAVIS_BUILD_DIR/RubikVNdotOrg/db/rubikvn_schema.sql


### PR DESCRIPTION
Only append to my.cnf in /etc/mysql/ instead of overwriting. We can do that inside our own docker container but I guess it's a different case for TravisCI